### PR TITLE
Feature executor end method

### DIFF
--- a/src/main/java/se/feomedia/orion/Executor.java
+++ b/src/main/java/se/feomedia/orion/Executor.java
@@ -38,9 +38,8 @@ public abstract class Executor<T extends Operation> {
     protected void begin(T operation, OperationTree node) {}
 
     protected final float process(float delta, Operation operation, OperationTree node) {
-        if (operation.isComplete()) {
+        if (operation.isComplete())
             return delta;
-        }
 
         if (!operation.started) {
             begin((T) operation, node);
@@ -49,7 +48,7 @@ public abstract class Executor<T extends Operation> {
 
         float dt = act(delta, (T) operation, node);
 
-        if (operation.isComplete()) {
+        if (operation.isComplete()){
             end((T) operation, node);
         }
 
@@ -57,12 +56,11 @@ public abstract class Executor<T extends Operation> {
     }
 
     /**
-     * Called when {@link Operation#isComplete()} returns true
+     * Called if {@link Operation#isComplete()} returns true.
      *
      * @param operation Current operation.
      * @param node Current node, hosting the operation.
      */
 
-    protected void end (T operation, OperationTree node) {
-    }
+    protected void end(T operation, OperationTree node) {}
 }

--- a/src/main/java/se/feomedia/orion/Executor.java
+++ b/src/main/java/se/feomedia/orion/Executor.java
@@ -16,36 +16,53 @@ import com.artemis.annotations.Wire;
  */
 @Wire
 public abstract class Executor<T extends Operation> {
-	public void initialize(World world) {}
+    public void initialize(World world) {}
 
-	/**
-	 * Updates the operation.
-	 *
-	 * @param delta since last frame
-	 * @param operation the operation
-	 * @param node node hosting this operation
-	 * @return new delta, may be same if operation was instant.
-	 */
-	protected abstract float act(float delta, T operation, OperationTree node);
+    /**
+     * Updates the operation.
+     *
+     * @param delta since last frame
+     * @param operation the operation
+     * @param node node hosting this operation
+     * @return new delta, may be same if operation was instant.
+     */
+    protected abstract float act(float delta, T operation, OperationTree node);
 
-	/**
-	 * Called before the first time {@link #act(float, Operation, OperationTree)}
-	 * is called.
-	 *
-	 * @param operation Current operation.
-	 * @param node Current node, hosting the operation.
-	 */
-	protected void begin(T operation, OperationTree node) {}
+    /**
+     * Called before the first time {@link #act(float, Operation, OperationTree)}
+     * is called.
+     *
+     * @param operation Current operation.
+     * @param node Current node, hosting the operation.
+     */
+    protected void begin(T operation, OperationTree node) {}
 
-	protected final float process(float delta, Operation operation, OperationTree node) {
-		if (operation.isComplete())
-			return delta;
+    protected final float process(float delta, Operation operation, OperationTree node) {
+        if (operation.isComplete()) {
+            return delta;
+        }
 
-		if (!operation.started) {
-			begin((T) operation, node);
-			operation.started = true;
-		}
+        if (!operation.started) {
+            begin((T) operation, node);
+            operation.started = true;
+        }
 
-		return act(delta, (T) operation, node);
-	}
+        float dt = act(delta, (T) operation, node);
+
+        if (operation.isComplete()) {
+            end((T) operation, node);
+        }
+
+        return dt;
+    }
+
+    /**
+     * Called when {@link Operation#isComplete()} returns true
+     *
+     * @param operation Current operation.
+     * @param node Current node, hosting the operation.
+     */
+
+    protected void end (T operation, OperationTree node) {
+    }
 }

--- a/src/test/java/se/feomedia/orion/operation/ExecutorEndTest.java
+++ b/src/test/java/se/feomedia/orion/operation/ExecutorEndTest.java
@@ -1,0 +1,85 @@
+package se.feomedia.orion.operation;
+
+import com.artemis.World;
+import com.artemis.WorldConfiguration;
+import com.artemis.annotations.Wire;
+import com.badlogic.gdx.graphics.Cursor;
+import com.sun.org.apache.xerces.internal.util.ShadowedSymbolTable;
+import org.junit.Test;
+import se.feomedia.orion.Executor;
+import se.feomedia.orion.Operation;
+import se.feomedia.orion.OperationTree;
+import se.feomedia.orion.system.OperationSystem;
+
+import static org.junit.Assert.assertEquals;
+import static se.feomedia.orion.OperationFactory.*;
+
+public class ExecutorEndTest {
+    @Test
+    public void end_test() {
+        World world = new World(new WorldConfiguration()
+                .setSystem(new OperationSystem()));
+
+        FiniteOperation fo = operation(FiniteOperation.class);
+
+        fo.register(world, world.create());
+
+        world.process();
+
+        assertEquals(1, fo.n);
+
+        world.process();
+
+        assertEquals(2, fo.n);
+
+        world.process();
+
+        assertEquals(-1, fo.n);
+
+        world.process();
+    }
+
+    public static class FiniteOperation extends Operation {
+        public int n;
+
+
+        @Override
+        public Class<? extends Executor> executorType() {
+            return FiniteExecutor.class;
+        }
+
+        @Override
+        protected boolean isComplete() {
+            return n > 2;
+        }
+
+        @Override
+        public void reset() {
+        }
+
+
+        @Wire
+        public static class FiniteExecutor extends Executor<FiniteOperation> {
+
+
+            @Override
+            protected float act(float delta, FiniteOperation operation, OperationTree node) {
+                operation.n++;
+                return 0;
+            }
+
+            @Override
+            protected void begin(FiniteOperation op, OperationTree node) {
+                op.n = 0;
+            }
+
+
+            protected void end(FiniteOperation operation, OperationTree node) {
+                operation.n = -1;
+            }
+
+
+        }
+    }
+
+}

--- a/src/test/java/se/feomedia/orion/operation/ExecutorEndTest.java
+++ b/src/test/java/se/feomedia/orion/operation/ExecutorEndTest.java
@@ -1,24 +1,23 @@
 package se.feomedia.orion.operation;
 
+import com.artemis.EntityManager;
 import com.artemis.World;
 import com.artemis.WorldConfiguration;
 import com.artemis.annotations.Wire;
-import com.badlogic.gdx.graphics.Cursor;
-import com.sun.org.apache.xerces.internal.util.ShadowedSymbolTable;
 import org.junit.Test;
 import se.feomedia.orion.Executor;
 import se.feomedia.orion.Operation;
 import se.feomedia.orion.OperationTree;
 import se.feomedia.orion.system.OperationSystem;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static se.feomedia.orion.OperationFactory.*;
 
 public class ExecutorEndTest {
     @Test
     public void end_test() {
         World world = new World(new WorldConfiguration()
-                .setSystem(new OperationSystem()));
+                .setSystem(OperationSystem.class));
 
         FiniteOperation fo = operation(FiniteOperation.class);
 
@@ -35,13 +34,11 @@ public class ExecutorEndTest {
         world.process();
 
         assertEquals(-1, fo.n);
-
-        world.process();
     }
 
-    public static class FiniteOperation extends Operation {
-        public int n;
 
+    public static class FiniteOperation extends Operation {
+        public int n = 0;
 
         @Override
         public Class<? extends Executor> executorType() {
@@ -55,13 +52,11 @@ public class ExecutorEndTest {
 
         @Override
         public void reset() {
-        }
 
+        }
 
         @Wire
         public static class FiniteExecutor extends Executor<FiniteOperation> {
-
-
             @Override
             protected float act(float delta, FiniteOperation operation, OperationTree node) {
                 operation.n++;
@@ -69,17 +64,14 @@ public class ExecutorEndTest {
             }
 
             @Override
-            protected void begin(FiniteOperation op, OperationTree node) {
-                op.n = 0;
+            protected void begin(FiniteOperation operation, OperationTree node) {
+                operation.n = 0;
             }
 
-
+            @Override
             protected void end(FiniteOperation operation, OperationTree node) {
                 operation.n = -1;
             }
-
-
         }
     }
-
 }


### PR DESCRIPTION
Like Executor.begin was conceived for initialization, Executor.end comes handy for cleanup purposes as well as reset operations since it can access both mappers and the current operation.
On the other hand, a trivial test has been added.