### PR TITLE
fix: remove unused imports to fix build on jitpack.io

### DIFF
--- a/src/main/java/se/feomedia/orion/OperationFactory.java
+++ b/src/main/java/se/feomedia/orion/OperationFactory.java
@@ -2,13 +2,11 @@ package se.feomedia.orion;
 
 import com.artemis.Entity;
 import com.badlogic.gdx.math.*;
-import com.badlogic.gdx.utils.Array;
 import se.feomedia.orion.operation.*;
 
 import static com.badlogic.gdx.math.Interpolation.linear;
 import static com.badlogic.gdx.utils.NumberUtils.floatToRawIntBits;
 import static com.badlogic.gdx.utils.NumberUtils.intBitsToFloat;
-import static java.lang.Math.max;
 
 public final class OperationFactory {
 	/**

--- a/src/main/java/se/feomedia/orion/OperationTree.java
+++ b/src/main/java/se/feomedia/orion/OperationTree.java
@@ -1,10 +1,8 @@
 package se.feomedia.orion;
 
-import com.artemis.link.MultiFieldMutator;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Pool;
 import se.feomedia.orion.system.OperationSystem;
-import sun.awt.image.MultiResolutionToolkitImage;
 
 /**
  * <p>The registered representation of an operation. Each node holds

--- a/src/test/java/se/feomedia/orion/JsonSerializationTest.java
+++ b/src/test/java/se/feomedia/orion/JsonSerializationTest.java
@@ -18,7 +18,6 @@ import se.feomedia.orion.system.OperationSystem;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.io.StringWriter;
 import java.nio.charset.StandardCharsets;
 
 import static com.artemis.Aspect.all;


### PR DESCRIPTION
the worse line here was: `import sun.awt.image.MultiResolutionToolkitImage;` 

Build error log:
https://jitpack.io/com/github/FEOMedia/artemis-odb-orion/cc24bdc77d/build.log