### PR TITLE
build(pom.xml): remove java-util from dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,12 +65,6 @@
 			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>com.cedarsoftware</groupId>
-			<artifactId>java-util</artifactId>
-			<version>1.19.3</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<build>


### PR DESCRIPTION
It is not used anywhere in the code.